### PR TITLE
fix mesh drop issue

### DIFF
--- a/src/ccall/src/goat.rs
+++ b/src/ccall/src/goat.rs
@@ -1,4 +1,5 @@
 use libc::c_void;
+use libc::c_char;
 use std::slice::from_raw_parts;
 
 // for writing obj file
@@ -13,7 +14,7 @@ extern "C" {
     fn my_init();
     fn my_exit();
     //fn breed(seed: c_int, dna1: *mut char, dna2: *mut char, outdna: *mut char, size: c_int); // commented out to exceed 80 chars
-    fn dump_goat(goat: *const c_void);
+    fn dump_goat(goat: *const c_void, filename: *const c_char);
     fn random_goat() -> *const c_void;
     fn free_goat(goat: *const c_void);
     fn breed_goat(goat1: *const c_void, goat2: *const c_void) -> *const c_void;
@@ -49,6 +50,7 @@ pub struct Mesh<'a> {
     mesh: &'a MeshInternal,
 }
 
+// TODO why are buffer timelines allowed to outlive mesh timelines?
 impl<'a> Mesh<'a> {
     pub fn buffers(&self) -> (&'a [f32], &'a [f32], &'a [f32], &'a [u32]) {
         let p = unsafe {
@@ -150,9 +152,13 @@ impl Goat {
         Mesh { mesh: &mesh }
     }
     #[allow(dead_code)]
-    pub fn dump(&self) {
+    pub fn dump(&self, filename: String) {
         unsafe {
-            dump_goat(self.hsptr);
+            let bytes : Vec<u8> = filename.into_bytes();
+            let mut cchar : Vec<c_char> = bytes.iter().map(|w| *w as c_char).collect();
+            let slice = cchar.as_mut_slice();
+            let ptr: *mut c_char = slice.as_mut_ptr();
+            dump_goat(self.hsptr, ptr);
         }
     }
 }

--- a/src/ccall/src/main.rs
+++ b/src/ccall/src/main.rs
@@ -46,9 +46,12 @@ fn breed_goats(
     println!("generating goat");
     for x in -2..3 {
         for y in -1..2 {
-            loop {
+            //loop {
+            {
                 let new_goat = breed(parent1, parent2);
-                let (p, n, tc, f) = new_goat.mesh().buffers();
+                let goat_mesh = new_goat.mesh();
+                let (p, n, tc, f) = goat_mesh.buffers();
+
                 let pos_vec = p
                     .to_vec()
                     .chunks(3)
@@ -85,6 +88,7 @@ fn breed_goats(
                 let faces_vec = f.to_vec();
                 // below is a hack to work around bad goat generation causing panics with mod_picking
                 if faces_vec.iter().all(|x| *x <= 900_000_000) {
+                    //eprintln!("{:?}", f);
                     mesh.set_indices(Some(Indices::U32(faces_vec)));
 
                     let mesh_handle = meshes.add(mesh);
@@ -109,10 +113,19 @@ fn breed_goats(
                         .with(HighlightablePickMesh::default())
                         .with(SelectablePickMesh::default());
 
-                    break;
+                    //break;
                 } else {
+
                     eprintln!("there is a bug that seems to be occuring more as you breed");
                     eprintln!("retrying");
+                    //eprintln!("{:?}", f);
+                    eprintln!("{:?}", f.as_ptr() as *const u32);
+                    let (p, n, tc, f) = goat_mesh.buffers();
+                    //eprintln!("{:?}", f);
+                    eprintln!("{:?}", f.as_ptr() as *const u32);
+                    let (p, n, tc, f) = goat_mesh.buffers();
+                    eprintln!("{:?}", f.as_ptr() as *const u32);
+                    //new_goat.dump(format!("goat{}.txt", new_goat.id));
                 };
             }
         }


### PR DESCRIPTION
Meshes were getting messed up because the Mesh object was getting dropped but the buffers were still being used. I thought lifetimes was suppose to prevent this from happening ... I guess I didn't do it right.